### PR TITLE
Add Google Analytics tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,16 +6,25 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<meta name="theme-color" content="#000000" />
 	<meta name="author" content="CodeCraft Team" />
-	<meta name="google" content="notranslate" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<meta name="description"
-		content="CodeCraft FSA - Especialistas em criação de sites e desenvolvimento web. Atendemos todo o Brasil com soluções digitais modernas, responsivas e profissionais para o seu negócio online." />
-	<meta name="keywords"
-		content="criação de sites, desenvolvimento web, sites, feira de santana, codecraft, codecraft fsa, codecraft feira de santana, web, desenvolvimento web feira de santana, sites feira de santana, empresa de sites, agência digital, negócio online, presença digital, soluções web" />
-	<link rel="icon" href="./public/favicon.png" type="image/png">
-	<link rel="apple-touch-icon" href="./public/logo192.png" />
-	<link rel="manifest" href="./public/manifest.json" />
-	<title>CodeCraft FSA - Criação de Sites e Desenvolvimento Web | Soluções Digitais Online</title>
+        <meta name="google" content="notranslate" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="description"
+                content="CodeCraft FSA - Especialistas em criação de sites e desenvolvimento web. Atendemos todo o Brasil com soluções digitais modernas, responsivas e profissionais para o seu negócio online." />
+        <meta name="keywords"
+                content="criação de sites, desenvolvimento web, sites, feira de santana, codecraft, codecraft fsa, codecraft feira de santana, web, desenvolvimento web feira de santana, sites feira de santana, empresa de sites, agência digital, negócio online, presença digital, soluções web" />
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-2F727BZKY5"></script>
+        <script>
+                window.dataLayer = window.dataLayer || [];
+                function gtag() { dataLayer.push(arguments); }
+                gtag('js', new Date());
+
+                gtag('config', 'G-2F727BZKY5');
+        </script>
+        <link rel="icon" href="./public/favicon.png" type="image/png">
+        <link rel="apple-touch-icon" href="./public/logo192.png" />
+        <link rel="manifest" href="./public/manifest.json" />
+        <title>CodeCraft FSA - Criação de Sites e Desenvolvimento Web | Soluções Digitais Online</title>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- implement Google Analytics via gtag.js in `index.html`

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_684b688ac120832bae560b0a63ddba44