### PR TITLE
Add canonical tag to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
         <link rel="icon" href="./public/favicon.png" type="image/png">
         <link rel="apple-touch-icon" href="./public/logo192.png" />
         <link rel="manifest" href="./public/manifest.json" />
+        <link rel="canonical" href="https://codecraft.social/" />
         <title>CodeCraft FSA - Criação de Sites e Desenvolvimento Web | Soluções Digitais Online</title>
 </head>
 


### PR DESCRIPTION
## Summary
- add canonical tag linking to `https://codecraft.social/` in the main `index.html`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d0dca8be4832b8ac72cfecaccf52f