### PR TITLE
Add Google Ads conversion tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,22 @@
                 gtag('config', 'G-2F727BZKY5');
                 gtag('config', 'AW-17180147170');
         </script>
+        <script>
+                function gtag_report_conversion(url) {
+                        var callback = function () {
+                                if (typeof url !== 'undefined') {
+                                        window.location = url;
+                                }
+                        };
+                        gtag('event', 'conversion', {
+                                send_to: 'AW-17180147170/AxgpCN7rvtoaEOL7kIBA',
+                                value: 1.0,
+                                currency: 'BRL',
+                                event_callback: callback
+                        });
+                        return false;
+                }
+        </script>
         <link rel="icon" href="./public/favicon.png" type="image/png">
         <link rel="apple-touch-icon" href="./public/logo192.png" />
         <link rel="manifest" href="./public/manifest.json" />

--- a/src/components/Whatsapp/Whatsapp.tsx
+++ b/src/components/Whatsapp/Whatsapp.tsx
@@ -1,10 +1,15 @@
 import './Whatsapp.css'
-import { sendAnalyticsEvent, sendGoogleAdsConversion } from '../../utils/analytics'
+import { sendAnalyticsEvent } from '../../utils/analytics'
 
 function Whatsapp(){
     const handleClick = () => {
         sendAnalyticsEvent('whatsapp_click', 'engagement', 'floating_button');
-        sendGoogleAdsConversion();
+        if (typeof window !== 'undefined') {
+            const report = (window as { gtag_report_conversion?: (url?: string) => void }).gtag_report_conversion;
+            if (typeof report === 'function') {
+                report();
+            }
+        }
     };
 
     return(


### PR DESCRIPTION
## Summary
- include `gtag_report_conversion` snippet for WhatsApp
- call the new conversion event from the WhatsApp button

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d16807564832b8a6ae92a36631bb8