### PR TITLE
Add Google Ads conversion tracking

### DIFF
--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -1,7 +1,11 @@
 import { useState, type FormEvent } from 'react';
 import './Contact.css';
 import instagram_logo from '../../assets/instagram_logo.png';
-import { sendAnalyticsEvent, sendGoogleAdsConversion } from '../../utils/analytics';
+import {
+  sendAnalyticsEvent,
+  sendGoogleAdsConversion,
+  gtagReportConversion,
+} from '../../utils/analytics';
 
 const Contact: React.FC = () => {
 	const [formData, setFormData] = useState({
@@ -97,6 +101,7 @@ const Contact: React.FC = () => {
                         window.open(whatsappURL, '_blank');
                         sendAnalyticsEvent('submit_form', 'contact', 'budget_form');
                         sendGoogleAdsConversion();
+                        gtagReportConversion();
 
 			console.log('Dados do formulário enviados para WhatsApp:', formData);
 			setSubmitSuccess(true);

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -28,3 +28,27 @@ export const sendGoogleAdsConversion = (): void => {
     }
   }
 };
+
+export const gtagReportConversion = (url?: string): boolean => {
+  if (typeof window !== 'undefined') {
+    const gtag = (window as { gtag?: (...args: unknown[]) => void }).gtag;
+
+    const callback = (): void => {
+      if (typeof url !== 'undefined') {
+        window.location.href = url;
+      }
+    };
+
+    if (typeof gtag === 'function') {
+      gtag('event', 'conversion', {
+        send_to: 'AW-17180147170/0s81CLyAuNoaEOL7kIBA',
+        value: 1.0,
+        currency: 'BRL',
+        event_callback: callback,
+      });
+      return false;
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
## Summary
- add `gtagReportConversion` helper for Google Ads
- trigger new conversion tracker on form submission

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d17ac3208832ba89f5b2fb8b95d20